### PR TITLE
認証とルーティング

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,29 @@
-import './App.css'
-import Top from './components/Top'
-import SignUp from './components/SignUp'
-import SignIn from './components/SignIn'
-import NotFound from './components/NotFound'
-import { BrowserRouter, Routes, Route} from "react-router-dom"
+import './App.css';
+import Top from './components/Top';
+import SignUp from './components/SignUp';
+import SignIn from './components/SignIn';
+import NotFound from './components/NotFound';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { PrivateRoute, GuestRoute } from './AuthRoute';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Top/>}/>
-        <Route path="/signin" element={<SignIn/>}/>
-        <Route path="/signup" element={<SignUp/>}/>
-        <Route path="*" element={<NotFound/>}/>
+        {/* トップページは認証済みユーザーのみ */}
+        <Route path="/" element={<PrivateRoute><Top /></PrivateRoute>} />
+
+        {/* サインインページはゲスト専用 */}
+        <Route path="/signin" element={<GuestRoute><SignIn /></GuestRoute>} />
+
+        {/* サインアップページはゲスト専用 */}
+        <Route path="/signup" element={<GuestRoute><SignUp /></GuestRoute>} />
+
+        {/* 404 Not Found ページ */}
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/AuthRoute.tsx
+++ b/frontend/src/AuthRoute.tsx
@@ -19,3 +19,17 @@ export const PrivateRoute = ({ children }: Props) => {
 
     return <Navigate to="/signin"/>
 }
+
+export const GuestRoute = ({ children }: Props) => {
+    const authInfo = useAuth();
+
+    if(!authInfo.checked){
+        return<div>Loading...</div>
+    }
+
+    if(!authInfo.isAuthenticated){
+        return <Navigate to='/'/>
+    }
+
+    return <>{children}</>
+}

--- a/frontend/src/AuthRoute.tsx
+++ b/frontend/src/AuthRoute.tsx
@@ -1,35 +1,43 @@
-import { ReactNode } from 'react'
+import { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "./hooks/useAuth";
 
 type Props = {
-    children: ReactNode
-}
+    children: ReactNode;
+};
 
+// 認証済みユーザー専用ルート
 export const PrivateRoute = ({ children }: Props) => {
     const authInfo = useAuth();
 
-    if(!authInfo.checked){
-        return<div>Loading...</div>
+    if (!authInfo.checked) {
+        // 認証チェック中のローディング表示
+        return <div>Loading...</div>;
     }
 
-    if(!authInfo.isAuthenticated){
-        return<>{children}</>
+    if (!authInfo.isAuthenticated) {
+        // 未認証の場合はサインインページへリダイレクト
+        return <Navigate to="/signin" />;
     }
 
-    return <Navigate to="/signin"/>
-}
+    // 認証済みの場合、子要素をレンダリング
+    return <>{children}</>;
+};
 
+// ゲストユーザー専用ルート
 export const GuestRoute = ({ children }: Props) => {
     const authInfo = useAuth();
 
-    if(!authInfo.checked){
-        return<div>Loading...</div>
+    if (!authInfo.checked) {
+        // 認証チェック中のローディング表示
+        return <div>Loading...</div>;
     }
 
-    if(!authInfo.isAuthenticated){
-        return <Navigate to='/'/>
+    if (authInfo.isAuthenticated) {
+        // 認証済みの場合はトップページへリダイレクト
+        return <Navigate to="/" />;
     }
 
-    return <>{children}</>
-}
+    // 未認証の場合、子要素をレンダリング
+    return <>{children}</>;
+};

--- a/frontend/src/AuthRoute.tsx
+++ b/frontend/src/AuthRoute.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./hooks/useAuth";
+
+type Props = {
+    children: ReactNode
+}
+
+export const PrivateRoute = ({ children }: Props) => {
+    const authInfo = useAuth();
+
+    if(!authInfo.checked){
+        return<div>Loading...</div>
+    }
+
+    if(!authInfo.isAuthenticated){
+        return<>{children}</>
+    }
+
+    return <Navigate to="/signin"/>
+}

--- a/frontend/src/hooks/UseAuth.ts
+++ b/frontend/src/hooks/UseAuth.ts
@@ -2,7 +2,7 @@ import { useEffect,useState } from "react"
 import { jwtDecode } from "jwt-decode";
 import { Payload } from "../types/payload";
 
-export const UseAuth =() => {
+export const useAuth =() => {
     const [authInfo,setAuthInfo] = useState<{
         checked: boolean,
         isAuthenticated: boolean,

--- a/frontend/src/hooks/UseAuth.ts
+++ b/frontend/src/hooks/UseAuth.ts
@@ -1,0 +1,31 @@
+import { useEffect,useState } from "react"
+import { jwtDecode } from "jwt-decode";
+import { Payload } from "../types/payload";
+
+export const UseAuth =() => {
+    const [authInfo,setAuthInfo] = useState<{
+        checked: boolean,
+        isAuthenticated: boolean,
+    }>({checked: false, isAuthenticated: false});
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        try {
+            if(token){
+                const decodedToken = jwtDecode<Payload>(token);
+                if (decodedToken.exp *1000 < Date.now()){
+                    localStorage.removeItem('token');
+                    setAuthInfo({checked: true, isAuthenticated: false})
+                } else {
+                    setAuthInfo({checked: true,isAuthenticated: true})
+                }
+            } else {
+                setAuthInfo({checked: true, isAuthenticated: false})
+            }
+        } catch (error) {
+            setAuthInfo({checked: true, isAuthenticated: false})
+        }
+    }, [])
+
+    return authInfo;
+}

--- a/frontend/src/types/payload.ts
+++ b/frontend/src/types/payload.ts
@@ -1,0 +1,6 @@
+export type Payload = {
+    email: string
+    sub: string
+    iat: number//iatはトークンが作成された時刻
+    exp: number//トークンの有効期限
+};


### PR DESCRIPTION
- http://localhost:5173だとhttp://localhost:5173/signinに遷移

<img width="1439" alt="スクリーンショット 2024-11-24 23 37 53" src="https://github.com/user-attachments/assets/2c0bbcb4-8eba-4ba3-9a06-82ab42e51374">

- http://localhost:5173/signin

<img width="1430" alt="スクリーンショット 2024-11-24 23 39 23" src="https://github.com/user-attachments/assets/1c204ce4-f475-4b18-bbc9-73f879cd6b36">

- http://localhost:5173/signup

<img width="1440" alt="スクリーンショット 2024-11-24 23 39 42" src="https://github.com/user-attachments/assets/1bdc1063-6805-4a96-b7b1-1c5e9112ecf9">

urlで特に何もない場合は、

<img width="1440" alt="スクリーンショット 2024-11-24 23 40 36" src="https://github.com/user-attachments/assets/7ebd06cc-16ae-4639-8309-cf4875c99e2b">

